### PR TITLE
feat(lobby): add host label and sort player list

### DIFF
--- a/Web/Www/Game/Controller/GameLobbyController.php
+++ b/Web/Www/Game/Controller/GameLobbyController.php
@@ -50,17 +50,19 @@ final class GameLobbyController extends Controller {
     $player = DB::selectOne(query: <<<SQL
       SELECT 
         bu.id, bu.display_name, bu.country_cca2, bu.user_level_enum as level,
-        gu.is_ready, gu.is_observer,
+        gu.is_ready, gu.is_observer, gu.created_at,
         mm.file_path as map_marker_file_path, mm.map_anchor as map_marker_map_anchor,
         ms.enum as map_style_enum, ms.short_name as map_style_short_name,
         COALESCE(uf.file_path, CONCAT('/static/flag/svg/', bu.country_cca2, '.svg')) as flag_file_path,
-        COALESCE(uf.description, bc.name) as flag_description
+        COALESCE(uf.description, bc.name) as flag_description,
+        CASE WHEN g.created_by_user_id = bu.id THEN true ELSE false END as is_host
       FROM game_user gu
       LEFT JOIN bear_user bu ON bu.id = gu.user_id
       LEFT JOIN bear_country bc ON bc.cca2 = bu.country_cca2
       LEFT JOIN map_marker mm ON mm.enum = bu.map_marker_enum
       LEFT JOIN map_style ms ON ms.enum = bu.map_style_enum
       LEFT JOIN user_flag uf ON uf.enum = bu.user_flag_enum
+      LEFT JOIN game g ON g.id = gu.game_id
       WHERE gu.game_id = ? AND gu.user_id = ?
     SQL, bindings: [$gameId, $userId]);
 
@@ -148,17 +150,19 @@ final class GameLobbyController extends Controller {
     $players = DB::select(query: <<<SQL
       SELECT 
         bu.id, bu.display_name, bu.country_cca2, bu.user_level_enum as level,
-        gu.is_ready, gu.is_observer,
+        gu.is_ready, gu.is_observer, gu.created_at,
         mm.file_path as map_marker_file_path, mm.map_anchor as map_marker_map_anchor,
         ms.enum as map_style_enum, ms.short_name as map_style_short_name,
         COALESCE(uf.file_path, CONCAT('/static/flag/svg/', bu.country_cca2, '.svg')) as flag_file_path,
-        COALESCE(uf.description, bc.name) as flag_description
+        COALESCE(uf.description, bc.name) as flag_description,
+        CASE WHEN g.created_by_user_id = bu.id THEN true ELSE false END as is_host
       FROM game_user gu
       LEFT JOIN bear_user bu ON bu.id = gu.user_id
       LEFT JOIN bear_country bc ON bc.cca2 = bu.country_cca2
       LEFT JOIN map_marker mm ON mm.enum = bu.map_marker_enum
       LEFT JOIN map_style ms ON ms.enum = bu.map_style_enum
       LEFT JOIN user_flag uf ON uf.enum = bu.user_flag_enum
+      LEFT JOIN game g ON g.id = gu.game_id
       WHERE gu.game_id = ?
       ORDER BY bu.id = ? DESC, bu.display_name, bu.country_cca2, bu.id
     SQL, bindings: [$gameId, BearAuthService::getUserId()]);

--- a/Web/Www/Game/View/lobby/index.blade.php
+++ b/Web/Www/Game/View/lobby/index.blade.php
@@ -155,7 +155,7 @@
         </div>
         <div x-ref="playerList" class="py-2">
           <div class="grid grid-cols-3 min-[420px]:grid-cols-4 min-[520px]:grid-cols-5 min-[622px]:grid-cols-6 gap-4">
-            <template x-for="player in players">
+            <template x-for="player in playerList">
               <div class="flex flex-col w-20 justify-center items-center">
                 <div class="flex w-full h-4 justify-center items-center px-0.5 rounded-t border border-b-0 border-gray-700 bg-gray-600" :tippy="player.display_name">
                   <span x-text="player.display_name" class="font-heading font-medium text-xs text-gray-0 truncate"></span>
@@ -198,11 +198,15 @@
 
       <lit-panel-header label="PLAYERS"></lit-panel-header>
       <div class="overflow-y-auto">
-        <template x-for="player in players">
-          <div class="flex gap-2 p-2 border-b border-gray-300 bg-gradient-to-t" :class="{ 
+        <template x-for="player in playerList">
+          <div class="flex gap-2 relative overflow-hidden p-2 border-b border-gray-300 bg-gradient-to-t" :class="{ 
             'from-pistachio-400 to-pistachio-500': player.is_ready, 
             'from-gray-50 to-gray-100': !player.is_ready 
             }">
+            <div x-show="player.is_host" class="flex justify-center items-center w-16 h-4 absolute top-2 -left-4 border border-gray-700 -rotate-45 bg-gradient-to-t from-yellow-300 to-yellow-400">
+              <span class="font-heading font-semibold text-xs text-gray-0 text-stroke-2 text-stroke-gray-700">HOST</span>
+            </div>
+
             <div class="flex flex-none justify-center w-16 h-16" :class="{ 'items-end': player.map_marker_map_anchor === 'bottom', 'items-center': player.map_marker_map_anchor === 'center' }">
               <img :src="player.map_marker_file_path" 
                 class="max-w-full max-h-full object-contain"
@@ -244,8 +248,15 @@
       game: @json($game),
       gameStageText: 'Waiting for players...',
       players: @json($players),
+      get playerList() {
+        const hostPlayer = this.players.find(n => n.is_host);
+        const noHostPlayers = this.players
+          .filter(n => n.is_host ? false : true)
+          .sort((a,b) => a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0);
+        return [hostPlayer, ...noHostPlayers];
+      },
       /** Returns a list of players for dev purpose only. */
-      get playersDev() {
+      get playerListDev() {
         const players = [];
         for(i=0; i<10;i++) {
           players.push( {


### PR DESCRIPTION
- Add a "Host" label for the host player.
- Ensure the host player is always displayed at the top of the player list.
- Other players are sorted by their order of joining the game.