### PR TITLE
feat(lit-components): rename 'title' property to prevent conflict

### DIFF
--- a/Web/Www/Game/View/result/index.blade.php
+++ b/Web/Www/Game/View/result/index.blade.php
@@ -226,17 +226,17 @@
           <div class="flex flex-col gap-2 p-2">
             @foreach ($players as $player)
               <lit-player-result-item
+                countryCCA2="{{ $player->country_cca2 }}"
                 detailedPoints="{{ $player->detailed_points }}"
-                flagFilePath="{{ $player->flag_file_path }}"
                 flagDescription="{{ $player->flag_description }}"
+                flagFilePath="{{ $player->flag_file_path }}"
+                iconPath="{{ $player->map_marker_file_path }}"
+                level="{{ $player->level }}"
+                name="{{ $player->display_name }}"
                 rank="{{ $player->rank }}"
                 rankSelected="{{ $player->rank === $user->rank ? $player->rank : '' }}"
-                title="{{ $player->title }}"
-                name="{{ $player->display_name }}"
-                iconPath="{{ $player->map_marker_file_path }}"
                 roundedPoints="{{ $player->rounded_points }}"
-                countryCCA2="{{ $player->country_cca2 }}"
-                level="{{ $player->level }}">
+                userTitle="{{ $player->title }}">
               </lit-player-result-item>
             @endforeach
           </div>

--- a/Web/Www/Shared/View/lit-components/achievement-progress-list.lit-component.js
+++ b/Web/Www/Shared/View/lit-components/achievement-progress-list.lit-component.js
@@ -128,7 +128,7 @@ class AchievementProgressList extends LitElement {
       <div class="flex flex-col gap-2">
         ${achievements.map(achievement => html`
           <lit-achievement-progress
-            .title="${achievement.title}"
+            name="${achievement.title}"
             description="${achievement.description}"
             .isCompleted="${achievement.isCompleted}"
             completedDate="${new Date().toISOString()}"

--- a/Web/Www/Shared/View/lit-components/achievement-progress.lit-component.js
+++ b/Web/Www/Shared/View/lit-components/achievement-progress.lit-component.js
@@ -4,11 +4,11 @@ import { TailwindStyles } from '../../../../../public/static/dist/lit-tailwind-c
 
 /**
  * Represents a player's progress on an achievement.
- * This component displays the title, description, and completion status of an achievement.
+ * This component displays the name, description, and completion status of an achievement.
  */
 class AchievementProgress extends LitElement {
   static properties = {
-    title: { type: String },
+    name: { type: String },
     description: { type: String },
     isCompleted: { type: Boolean },
     completedDate: { type: String },
@@ -39,7 +39,7 @@ class AchievementProgress extends LitElement {
   render() {
     return html`
       <div class="flex flex-col min-h-24 relative border border-gray-200 rounded p-2 bg-gray-0">
-        <span class="mr-8 font-medium text-base text-iris-600">${this.title}</span>
+        <span class="mr-8 font-medium text-base text-iris-600">${this.name}</span>
         <span class="mr-8 text-sm text-gray-700">${this.description}</span>
         
         ${!this.isCompleted && this.hasSteps ? html`

--- a/Web/Www/Shared/View/lit-components/player-result-item.lit-component.js
+++ b/Web/Www/Shared/View/lit-components/player-result-item.lit-component.js
@@ -21,7 +21,7 @@ class PlayerResultItem extends LitElement {
     rank: { type: Number },
     rankSelected: { type: Number },
     roundedPoints: { type: Number },
-    title: { type: String },
+    userTitle: { type: String },
   }
 
   static styles = css`${TailwindStyles}`;
@@ -141,7 +141,7 @@ class PlayerResultItem extends LitElement {
                 <img src="/static/img/icon/emblem.svg" class="h-5" />
                 <span class="absolute text-white font-heading text-base font-bold text-stroke-2 text-stroke-iris-900">${this.level}</span>
               </div>
-              <div class="text-xs sm:text-sm text-gray-700 truncate select-text">${this.title}</div>
+              <div class="text-xs sm:text-sm text-gray-700 truncate select-text">${this.userTitle}</div>
             </div>
           </div>
         </div>

--- a/Web/Www/Shared/View/lit-components/round-result-ranking-dialog-button.lit-component.js
+++ b/Web/Www/Shared/View/lit-components/round-result-ranking-dialog-button.lit-component.js
@@ -59,12 +59,12 @@ class RoundResultRankingDialogButton extends LitElement {
               distanceMeters="${guess.distance_meters}"
               flagFilePath="${guess.user_flag_file_path}"
               flagDescription="${guess.user_flag_description}"
-              .title="${guess.title}"
               iconPath="${guess.map_marker_file_path}"
               level="${guess.user_level}"
               name="${guess.user_display_name}"
               rank="${guess.rank}"
-              roundedPoints="${guess.rounded_points}">
+              roundedPoints="${guess.rounded_points}"
+              userTitle="${guess.title}">
             </lit-player-result-item>
           `)}
         </div>


### PR DESCRIPTION
Rename the 'title' property in lit-components to prevent it from being treated as the standard HTML attribute.