### PR TITLE
fix(dialog) prevent event listeners from being removed

### DIFF
--- a/Web/Www/Shared/View/lit-components/dialog.lit-component.ts
+++ b/Web/Www/Shared/View/lit-components/dialog.lit-component.ts
@@ -110,12 +110,6 @@ export class Dialog extends LitElement {
   }
 
   private handleClose() {
-    const dialog = this.getDialogElement()
-    if (dialog) {
-      dialog.removeEventListener("click", this.onBackdropClickHandler)
-      dialog.removeEventListener("close", this.onCloseHandler)
-    }
-
     const footerSlotEl = this.shadowRoot?.querySelector('slot[name="footer"]') as HTMLSlotElement
     if (footerSlotEl) {
       footerSlotEl.removeEventListener("slotchange", this.onSlotChangeHandler)


### PR DESCRIPTION
I think I was removing the event listeners because I thought the dialog was removed after being closed, but that's not the case.